### PR TITLE
Add more fields to redact list in config

### DIFF
--- a/config/hindsight.php
+++ b/config/hindsight.php
@@ -41,10 +41,10 @@ return [
             'enable' => null,
             'redact' => [
                 'fields'  => [
-                    'password', 'confirm_password', 'cvv', 'cvc', 'cvv2', 'card_number', 'ssn', 'ni_number',
+                    'password', 'confirm_password', 'cvv', 'cvc', 'cvv2', 'card_number', 'ssn', 'ni_number', 'api_key',
                 ],
                 'headers' => [
-                    'Authorization'
+                    'Authorization', 'Cookie', 'Set-Cookie',
                 ],
             ],
             'extras' => [


### PR DESCRIPTION
Adds a few more fields/headers to redact in logs. `Cookie` and `Set-Cookie` are headers that can transport sensitive information like session tokens between client and server, so should be excluded.